### PR TITLE
fix: Change secret name for GitHub token

### DIFF
--- a/.github/workflows/release-tagger-for-github-workflows.yaml
+++ b/.github/workflows/release-tagger-for-github-workflows.yaml
@@ -12,7 +12,7 @@ on:
         required: true
         description: Tag name being released.
     secrets:
-      GITHUB_TOKEN:
+      GH_TOKEN:
         required: true
 
 defaults:
@@ -54,4 +54,4 @@ jobs:
           git tag -f "$NEW_TAG"
 
           # Force push the updated tag
-          git push -f https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }} refs/tags/"$NEW_TAG"
+          git push -f https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }} refs/tags/"$NEW_TAG"

--- a/.github/workflows/update-major-tag.yaml
+++ b/.github/workflows/update-major-tag.yaml
@@ -11,6 +11,6 @@ jobs:
     with:
       tag-name: ${{ github.event.release.tag_name }}
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: write


### PR DESCRIPTION
"secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name"