### PR TITLE
fix: Correct concurrency group

### DIFF
--- a/.github/workflows/release-tagger-for-github-workflows.yaml
+++ b/.github/workflows/release-tagger-for-github-workflows.yaml
@@ -1,7 +1,7 @@
 name: Release Tagger
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 on:


### PR DESCRIPTION
If the group name is based on ref, then it will create new concurrency group for each release. They should be concurrent for the workflow. That way, subsequent releases are run sequentially.

> 
github.ref | string -- | --For workflows triggered by release, this is the release tag created.

ref: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs