### PR TITLE
fix: spec must have lifecycle

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,3 +8,4 @@ metadata:
 spec:
   type: library
   owner: engineering
+  lifecycle: production


### PR DESCRIPTION
In backstage logs: 

> [backend]: 2025-04-10T10:05:16.226Z catalog warn Processor BuiltinKindsEntityProcessor threw an error while validating the entity component:default/github-workflow-release-tagger-for-github-workflows; caused by TypeError: /spec must have required property 'lifecycle' - missingProperty: lifecycle entity=component:default/github-workflow-release-tagger-for-github-workflows location=url:https://github.com/coopnorge/github-workflow-release-tagger-for-github-workflows/tree/main/catalog-info.yaml
